### PR TITLE
Do not create /tmp

### DIFF
--- a/examples/deploy.rb
+++ b/examples/deploy.rb
@@ -20,7 +20,6 @@ set :use_sudo, false
 before "deploy:finalize_update" do
   run "rm -f #{release_path}/config/database.yml; ln -nfs #{shared_path}/config/database.yml #{release_path}/config/database.yml"
   run "rm -f #{release_path}/log; ln -nfs #{shared_path}/log #{release_path}/log"
-  run "mkdir #{release_path}/tmp;"
   run "ln -nfs #{shared_path}/pids #{release_path}/tmp/pids"
   run "ln -nfs #{shared_path}/sockets #{release_path}/tmp/sockets"
   run "ln -nfs #{shared_path}/../config/unicorn.rb #{release_path}/config/unicorn.rb"


### PR DESCRIPTION
Here's what I get without the patch:

```
 ** [out :: 185.10.48.88] mkdir: cannot create directory `/u/apps/application/releases/20130128174244/tmp'
 ** [out :: 185.10.48.88] : File exists
    command finished in 277ms
*** [deploy:update_code] rolling back
```

Apparently the `tmp` directory gets created somewhere before and it breaks the deployment.
