### PR TITLE
#16 addressed in sample_host.json, now there is a node for deploy users

### DIFF
--- a/nodes/sample_host.json
+++ b/nodes/sample_host.json
@@ -13,6 +13,9 @@
     "server_root_password": "<a random password>",
     "server_repl_password": "<a random password>"
   },
+  "deploy_users": [
+    "<add as many users as you want to create to deploy>"
+  ]
   "ssh_deploy_keys": [
     "<the contents of your ~/.ssh/id_rsa.pub file>"
   ],


### PR DESCRIPTION
Originally this was missing, so even cooking a server wouldn't add SSH keys to users.
