### PR TITLE
Fix hard-coded .pill file name in upstart script.

### DIFF
--- a/cookbooks/rails/templates/default/bluepill_upstart.erb
+++ b/cookbooks/rails/templates/default/bluepill_upstart.erb
@@ -5,5 +5,5 @@ expect daemon
 respawn
 
 script
-  <%= node["bluepill"]["bin"] %> load /etc/bluepill/intercity_development.pill
+  <%= node["bluepill"]["bin"] %> load /etc/bluepill/<%= @name %>.pill
 end script


### PR DESCRIPTION
The .pill filename is generated from the application name, so the Upstart script should point to this filename.
