### PR TITLE
build nodejs from binaries

### DIFF
--- a/cookbooks/nodejs/Berksfile
+++ b/cookbooks/nodejs/Berksfile
@@ -1,0 +1,5 @@
+site :opscode
+metadata
+
+cookbook 'apt', '~> 1.7.0'
+cookbook 'build-essential'

--- a/cookbooks/nodejs/CHANGELOG.md
+++ b/cookbooks/nodejs/CHANGELOG.md
@@ -1,0 +1,56 @@
+## v1.3.0
+  * update default versions to the latest: node - v0.10.15 and npm - v1.3.5
+  * default to package installation of nodejs on smartos ([@wanelo-pair][])
+  * Add Raspberry pi support ([@robertkowalski][])
+
+## v1.2.0
+  * implement installation from package on RedHat - ([@vaskas][])
+
+## v1.1.3:
+  * update default version of node to 0.10.13 - and npm - v1.3.4 ([@jodosha][])
+
+## v1.1.2:
+  * update default version of node to 0.10.2 - ([@bakins][])
+  * fully migrated to test-kitchen 1.alpha and vagrant 1.1.x/berkshelf 1.3.1
+
+## v1.1.1:
+  * update default versions to the latest: node - v0.10.0 and npm - v1.2.14
+  * `make_thread` is now a real attribute - ([@ChrisLundquist][])
+
+
+## v1.1.0:
+  * rewrite the package install; remove rpm support since there are no longer any packages available anywhere
+  * add support to install `legacy_packages` from ubuntu repo as well as the latest 0.10.x branch (this is default).
+
+## v1.0.4:
+  * add support for binary installation method ([@JulesAU][])
+
+## v1.0.3:
+  - unreleased
+
+## v1.0.2:
+  * add smartos support for package install ([@sax][])
+  * support to compile with all processors available (default 2 if unknown) - ([@ChrisLundquist][])
+  * moved to `platform_family` syntax
+  * ensure npm recipe honours the 'source' or 'package' setting - ([@markbirbeck][])
+  * updated the default versions to the latest stable node/npm
+
+## v1.0.1:
+
+ * fixed bug that prevented overwritting the node/npm versions (moved the `src_url`s as local variables instead of attributes) - ([@johannesbecker][])
+ * updated the default versions to the latest node/npm
+
+## v1.0.0:
+
+* added packages installation support ([@smith][])
+
+[@JulesAU]: https://github.com/JulesAU
+[@sax]: https://github.com/sax
+[@ChrisLundquist]: https://github.com/ChrisLundquist
+[@markbirbeck]: https://github.com/markbirbeck
+[@johannesbecker]: https://github.com/johannesbecker
+[@smith]: https://github.com/smith
+[@bakins]: https://github.com/bakins
+[@vaskas]: https://github.com/vaskas
+[@robertkowalski]: https://github.com/robertkowalski
+[@wanelo-pair]: https://github.com/wanelo-pair

--- a/cookbooks/nodejs/Gemfile
+++ b/cookbooks/nodejs/Gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'foodcritic'
+gem 'thor-foodcritic'
+
+group :integration do
+  gem 'berkshelf'
+  gem 'test-kitchen', '~> 1.0.0.beta'
+  gem 'kitchen-vagrant', '~> 0.11.0'
+end

--- a/cookbooks/nodejs/README.md
+++ b/cookbooks/nodejs/README.md
@@ -1,0 +1,80 @@
+# <a name="title"></a> nodejs-cookbook [![Build Status](https://secure.travis-ci.org/mdxp/nodejs-cookbook.png)](http://travis-ci.org/mdxp/nodejs-cookbook)
+
+DESCRIPTION
+===========
+
+Installs Node.JS
+
+REQUIREMENTS
+============
+
+
+## Platform
+
+* Tested on Debian 6 and Ubuntu 10.04
+* Should work fine on Centos, RHEL, etc.
+
+## Cookbooks:
+
+* build-essential
+* apt
+
+Opscode cookbooks (http://github.com/opscode/cookbooks/tree/master)
+
+ATTRIBUTES
+==========
+
+* nodejs['install_method'] = source or package
+* nodejs['version'] - release version of node to install
+* nodejs['src_url'] - download location for node source tarball
+* nodejs['dir'] - location where node will be installed, default /usr/local
+* nodejs['npm'] - version of npm to install
+* nodejs['npm_src_url'] - download location for npm source tarball
+* nodejs['check_sha'] - test for valid sha_sum, default: true
+
+USAGE
+=====
+
+Include the nodejs recipe to install node on your system based on the default installation method:
+
+*  include_recipe "nodejs"
+
+Include the install_from_source recipe to install node from sources:
+
+*  include_recipe "nodejs::install_from_source"
+
+Include the install_from_package recipe to install node from packages:
+Note that only apt (Ubuntu, Debian) appears to have up to date packages available.
+Centos, RHEL, etc are non-functional. (Try install_from_binary for those)
+
+*  include_recipe "nodejs::install_from_package"
+
+Include the install_from_binary recipe to install node from official prebuilt binaries:
+(Currently Linux x86, x86_64, armv6l only)
+
+*  include_recipe "nodejs::install_from_binary"
+
+Include the npm recipe to install npm:
+
+*  include_recipe "nodejs::npm"
+
+LICENSE and AUTHOR
+==================
+
+Author:: Marius Ducea (marius@promethost.com)
+Author:: Nathan L Smith (nlloyds@gmail.com)
+
+Copyright:: 2010-2012, Promet Solutions
+Copyright:: 2012, Cramer Development, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/cookbooks/nodejs/attributes/default.rb
+++ b/cookbooks/nodejs/attributes/default.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: nodejs
+# Attributes:: nodejs
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform_family']
+  when "smartos"
+    default['nodejs']['install_method'] = 'package'
+  else
+    default['nodejs']['install_method'] = 'source'
+end
+
+default['nodejs']['version'] = '0.10.15'
+default['nodejs']['checksum'] = '87345ab3b96aa02c5250d7b5ae1d80e620e8ae2a7f509f7fa18c4aaa340953e8'
+default['nodejs']['checksum_linux_x64'] = '0b5191748a91b1c49947fef6b143f3e5e5633c9381a31aaa467e7c80efafb6e9'
+default['nodejs']['checksum_linux_x86'] = '7ff9fb6aa19a5269a5a2f7a770040b8cd3c3b528a9c7c07da5da31c0d6dfde4d'
+default['nodejs']['dir'] = '/usr/local'
+default['nodejs']['npm'] = '1.3.5'
+default['nodejs']['src_url'] = "http://nodejs.org/dist"
+default['nodejs']['make_threads'] = node['cpu'] ? node['cpu']['total'].to_i : 2
+default['nodejs']['check_sha'] = true
+
+# Set this to true to install the legacy packages (0.8.x) from ubuntu/debian repositories; default is false (using the latest stable 0.10.x)
+default['nodejs']['legacy_packages'] = false

--- a/cookbooks/nodejs/metadata.json
+++ b/cookbooks/nodejs/metadata.json
@@ -1,0 +1,43 @@
+{
+  "name": "nodejs",
+  "description": "Installs/Configures nodejs",
+  "long_description": "# <a name=\"title\"></a> nodejs-cookbook [![Build Status](https://secure.travis-ci.org/mdxp/nodejs-cookbook.png)](http://travis-ci.org/mdxp/nodejs-cookbook)\n\nDESCRIPTION\n===========\n\nInstalls Node.JS\n\nREQUIREMENTS\n============\n\n\n## Platform\n\n* Tested on Debian 6 and Ubuntu 10.04\n* Should work fine on Centos, RHEL, etc.\n\n## Cookbooks:\n\n* build-essential\n* apt\n\nOpscode cookbooks (http://github.com/opscode/cookbooks/tree/master)\n\nATTRIBUTES\n==========\n\n* nodejs['install_method'] = source or package\n* nodejs['version'] - release version of node to install\n* nodejs['src_url'] - download location for node source tarball\n* nodejs['dir'] - location where node will be installed, default /usr/local\n* nodejs['npm'] - version of npm to install\n* nodejs['npm_src_url'] - download location for npm source tarball\n* nodejs['check_sha'] - test for valid sha_sum, default: true\n\nUSAGE\n=====\n\nInclude the nodejs recipe to install node on your system based on the default installation method:\n\n*  include_recipe \"nodejs\"\n\nInclude the install_from_source recipe to install node from sources:\n\n*  include_recipe \"nodejs::install_from_source\"\n\nInclude the install_from_package recipe to install node from packages:\nNote that only apt (Ubuntu, Debian) appears to have up to date packages available.\nCentos, RHEL, etc are non-functional. (Try install_from_binary for those)\n\n*  include_recipe \"nodejs::install_from_package\"\n\nInclude the install_from_binary recipe to install node from official prebuilt binaries:\n(Currently Linux x86, x86_64, armv6l only)\n\n*  include_recipe \"nodejs::install_from_binary\"\n\nInclude the npm recipe to install npm:\n\n*  include_recipe \"nodejs::npm\"\n\nLICENSE and AUTHOR\n==================\n\nAuthor:: Marius Ducea (marius@promethost.com)\nAuthor:: Nathan L Smith (nlloyds@gmail.com)\n\nCopyright:: 2010-2012, Promet Solutions\nCopyright:: 2012, Cramer Development, Inc.\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+  "maintainer": "Promet Solutions",
+  "maintainer_email": "marius@promethost.com",
+  "license": "Apache 2.0",
+  "platforms": {
+    "debian": ">= 0.0.0",
+    "ubuntu": ">= 0.0.0",
+    "centos": ">= 0.0.0",
+    "redhat": ">= 0.0.0",
+    "smartos": ">= 0.0.0"
+  },
+  "dependencies": {
+    "apt": ">= 0.0.0",
+    "yum": ">= 0.0.0",
+    "build-essential": ">= 0.0.0"
+  },
+  "recommendations": {
+  },
+  "suggestions": {
+  },
+  "conflicting": {
+  },
+  "providing": {
+    "nodejs": ">= 0.0.0"
+  },
+  "replacing": {
+  },
+  "attributes": {
+  },
+  "groupings": {
+  },
+  "recipes": {
+    "nodejs": "Installs Node.JS based on the default installation method",
+    "nodejs::install_from_source": "Installs Node.JS from source",
+    "nodejs::install_from_binary": "Installs Node.JS from official binaries",
+    "nodejs::install_from_package": "Installs Node.JS from packages",
+    "nodejs::npm": "Installs npm from source - a package manager for node"
+  },
+  "version": "1.3.0"
+}

--- a/cookbooks/nodejs/metadata.rb
+++ b/cookbooks/nodejs/metadata.rb
@@ -1,0 +1,22 @@
+maintainer       "Promet Solutions"
+maintainer_email "marius@promethost.com"
+license          "Apache 2.0"
+description      "Installs/Configures nodejs"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "1.3.0"
+name             "nodejs"
+provides         "nodejs"
+
+recipe "nodejs", "Installs Node.JS based on the default installation method"
+recipe "nodejs::install_from_source", "Installs Node.JS from source"
+recipe "nodejs::install_from_binary", "Installs Node.JS from official binaries"
+recipe "nodejs::install_from_package", "Installs Node.JS from packages"
+recipe "nodejs::npm", "Installs npm from source - a package manager for node"
+
+%w{ apt yum build-essential }.each do |c|
+  depends c
+end
+
+%w{ debian ubuntu centos redhat smartos }.each do |os|
+    supports os
+end

--- a/cookbooks/nodejs/recipes/default.rb
+++ b/cookbooks/nodejs/recipes/default.rb
@@ -1,0 +1,25 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: default
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+case node['platform_family']
+  when "debian"
+   include_recipe "apt"
+end
+
+include_recipe "nodejs::install_from_#{node['nodejs']['install_method']}"

--- a/cookbooks/nodejs/recipes/install_from_binary.rb
+++ b/cookbooks/nodejs/recipes/install_from_binary.rb
@@ -1,0 +1,80 @@
+#
+# Author:: Julian Wilde (jules@jules.com.au)
+# Cookbook Name:: nodejs
+# Recipe:: install_from_binary
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# Shamelessly borrowed from http://docs.opscode.com/dsl_recipe_method_platform.html
+# Surely there's a more canonical way to get arch?
+if node['kernel']['machine'] =~ /armv6l/
+  arch = "arm-pi" # assume a raspberry pi
+else
+  arch = node['kernel']['machine'] =~ /x86_64/ ? "x64" : "x86"
+end
+
+distro_suffix = "-linux-#{arch}"
+
+# package_stub is for example: "node-v0.8.20-linux-x64"
+package_stub = "node-v#{node['nodejs']['version']}#{distro_suffix}"
+nodejs_tar = "#{package_stub}.tar.gz"
+expected_checksum = node['nodejs']["checksum_linux_#{arch}"]
+
+nodejs_tar_path = nodejs_tar
+if node['nodejs']['version'].split('.')[1].to_i >= 5
+  nodejs_tar_path = "v#{node['nodejs']['version']}/#{nodejs_tar_path}"
+end
+
+# Let the user override the source url in the attributes
+nodejs_bin_url = "#{node['nodejs']['src_url']}/#{nodejs_tar_path}"
+
+# Download it:
+remote_file "/usr/local/src/#{nodejs_tar}" do
+  source nodejs_bin_url
+  checksum expected_checksum
+  mode 0644
+  action :create_if_missing
+end
+
+# Where we will install the binaries and libs to (normally /usr/local):
+destination_dir = node['nodejs']['dir']
+
+install_not_needed = File.exists?("#{node['nodejs']['dir']}/bin/node") && `#{node['nodejs']['dir']}/bin/node --version`.chomp == "v#{node['nodejs']['version']}" 
+
+# Verify the SHA sum of the downloaded file:
+ruby_block "verify_sha_sum" do
+    block do
+        require 'digest/sha1'
+        calculated_sha256_hash = Digest::SHA256.file("/usr/local/src/#{nodejs_tar}")
+        if calculated_sha256_hash != expected_checksum
+            raise "SHA256 Hash of #{nodejs_tar} did not match!  Expected #{expected_checksum} found #{calculated_sha256_hash}"
+        end
+    end
+    not_if { !node['nodejs']['check_sha'] or install_not_needed }
+end
+
+# One hopes that we can trust the contents of the node tarball not to overwrite anything it shouldn't!
+execute "install package to system" do
+    command <<-EOF
+            tar xf /usr/local/src/#{nodejs_tar} \
+            --strip-components=1  --no-same-owner \
+            -C #{destination_dir} \
+            #{package_stub}/bin \
+            #{package_stub}/lib \
+            #{package_stub}/share
+        EOF
+
+    not_if { install_not_needed }
+end

--- a/cookbooks/nodejs/recipes/install_from_package.rb
+++ b/cookbooks/nodejs/recipes/install_from_package.rb
@@ -1,0 +1,52 @@
+#
+# Author:: Nathan L Smith (nlloyds@gmail.com)
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: package
+#
+# Copyright 2012, Cramer Development, Inc.
+# Copyright 2013, Opscale
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform_family']
+  when 'debian'
+    if node['nodejs']['legacy_packages'] == true
+      repo = 'http://ppa.launchpad.net/chris-lea/node.js-legacy/ubuntu'
+      packages = %w{ nodejs npm }
+    else
+      repo = 'http://ppa.launchpad.net/chris-lea/node.js/ubuntu'
+      packages = %w{ nodejs }
+    end
+    apt_repository 'node.js' do
+      uri repo
+      distribution node['lsb']['codename']
+      components ['main']
+      keyserver "keyserver.ubuntu.com"
+      key "C7917B12"
+      action :add
+    end
+  when 'rhel'
+    include_recipe 'yum::epel'
+    packages = %w{ nodejs nodejs-devel npm }
+  when 'smartos'
+    packages = %w{ nodejs }
+  else
+    Chef::Log.error "There are no nodejs packages for this platform; please use the source or binary method to install node"
+    return
+end
+
+packages.each do |node_pkg|
+  package node_pkg
+end

--- a/cookbooks/nodejs/recipes/install_from_source.rb
+++ b/cookbooks/nodejs/recipes/install_from_source.rb
@@ -1,0 +1,68 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: source
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "build-essential"
+
+case node['platform_family']
+  when 'rhel','fedora'
+    package "openssl-devel"
+  when 'debian'
+    package "libssl-dev"
+end
+
+nodejs_tar = "node-v#{node['nodejs']['version']}.tar.gz"
+nodejs_tar_path = nodejs_tar
+if node['nodejs']['version'].split('.')[1].to_i >= 5
+  nodejs_tar_path = "v#{node['nodejs']['version']}/#{nodejs_tar_path}"
+end
+# Let the user override the source url in the attributes
+nodejs_src_url = "#{node['nodejs']['src_url']}/#{nodejs_tar_path}"
+
+remote_file "/usr/local/src/#{nodejs_tar}" do
+  source nodejs_src_url
+  checksum node['nodejs']['checksum']
+  mode 0644
+  action :create_if_missing
+end
+
+# --no-same-owner required overcome "Cannot change ownership" bug
+# on NFS-mounted filesystem
+execute "tar --no-same-owner -zxf #{nodejs_tar}" do
+  cwd "/usr/local/src"
+  creates "/usr/local/src/node-v#{node['nodejs']['version']}"
+end
+
+bash "compile node.js (on #{node['nodejs']['make_threads']} cpu)" do
+  # OSX doesn't have the attribute so arbitrarily default 2
+  cwd "/usr/local/src/node-v#{node['nodejs']['version']}"
+  code <<-EOH
+    PATH="/usr/local/bin:$PATH"
+    ./configure --prefix=#{node['nodejs']['dir']} && \
+    make -j #{node['nodejs']['make_threads']}
+  EOH
+  creates "/usr/local/src/node-v#{node['nodejs']['version']}/node"
+end
+
+execute "nodejs make install" do
+  environment({"PATH" => "/usr/local/bin:/usr/bin:/bin:$PATH"})
+  command "make install"
+  cwd "/usr/local/src/node-v#{node['nodejs']['version']}"
+  not_if {::File.exists?("#{node['nodejs']['dir']}/bin/node") && `#{node['nodejs']['dir']}/bin/node --version`.chomp == "v#{node['nodejs']['version']}" }
+end

--- a/cookbooks/nodejs/recipes/npm.rb
+++ b/cookbooks/nodejs/recipes/npm.rb
@@ -1,0 +1,38 @@
+#
+# Author:: Marius Ducea (marius@promethost.com)
+# Cookbook Name:: nodejs
+# Recipe:: npm
+#
+# Copyright 2010-2012, Promet Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "nodejs"
+
+package "curl"
+
+npm_src_url = "http://registry.npmjs.org/npm/-/npm-#{node['nodejs']['npm']}.tgz"
+
+bash "install npm - package manager for node" do
+  cwd "/usr/local/src"
+  user "root"
+  code <<-EOH
+    mkdir -p npm-v#{node['nodejs']['npm']} && \
+    cd npm-v#{node['nodejs']['npm']}
+    curl -L #{npm_src_url} | tar xzf - --strip-components=1 && \
+    make uninstall dev
+  EOH
+  not_if "#{node['nodejs']['dir']}/bin/npm -v 2>&1 | grep '#{node['nodejs']['npm']}'"
+end
+

--- a/nodes/sample_host.json
+++ b/nodes/sample_host.json
@@ -1,5 +1,5 @@
 {
-  "run_list":["role[mysql]","role[rails]"],
+  "run_list":["role[mysql]","role[nodejs]","role[rails]"],
   "authorization": {
     "sudo": {
       "users": ["<your user>"],
@@ -22,7 +22,7 @@
   "active_applications": {
     "myapp_production": {
       "rails_env": "production",
-      "packages": ["nodejs"],
+      "packages": [],
       "domain_names": ["myapp.com", "www.myapp.com"],
       "database_info": {
         "adapter": "mysql2",

--- a/roles/nodejs.rb
+++ b/roles/nodejs.rb
@@ -1,0 +1,3 @@
+name 'nodejs'
+description 'installing nodeJS'
+run_list "recipe[build-essential]","recipe[apt]", "nodejs::install_from_binary"


### PR DESCRIPTION
I was getting errors (see dump below) when the trying to install nodejs as a package.
Not sure if anyone else was experiencing it.

I'm using linode, Ubuntu 12.04 LTS 32bit Disk Image (48896 MB, ext3) image.

``` sh
Recipe: rails::dependencies
  * package[nodejs] action install
    * No version specified, and no candidate version available for nodejs
================================================================================
Error executing action `install` on resource 'package[nodejs]'
================================================================================


Chef::Exceptions::Package
-------------------------
No version specified, and no candidate version available for nodejs


Resource Declaration:
---------------------
# In /root/chef-solo/cookbooks-1/rails/recipes/dependencies.rb

  6:         package package
  7:       end



Compiled Resource:
------------------
# Declared in /root/chef-solo/cookbooks-1/rails/recipes/dependencies.rb:6:in `block (2 levels) in from_file'

package("nodejs") do
  action :install
  retries 0
  retry_delay 2
  package_name "nodejs"
  cookbook_name :rails
  recipe_name "dependencies"
end



[2013-11-26T23:02:49+00:00] ERROR: Running exception handlers
[2013-11-26T23:02:49+00:00] ERROR: Exception handlers complete
Chef Client failed. 2 resources updated
[2013-11-26T23:02:49+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2013-11-26T23:02:49+00:00] FATAL: Chef::Exceptions::Package: package[nodejs] (rails::dependencies line 6) had an error: Chef::Exceptions::Package: No version specified, and no candidate version available for nodejs

```
