### PR TITLE
remove extra comma causing JSON parse error when running cook

### DIFF
--- a/nodes/sample_host.json
+++ b/nodes/sample_host.json
@@ -7,7 +7,7 @@
   },
   "authorization": {
     "sudo": {
-      "users": ["<your sudo user>"],
+      "users": ["<your sudo user>"]
     }
   },
   "ssh_deploy_keys": [


### PR DESCRIPTION
Fix to remove extra comma causing this error when running "knife solo cook user@host"

ERROR: JSON::ParserError: 757: unexpected token at
