### PR TITLE
Add back vendor/bundler recipe from old versions of repo and use it in C...

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -11,6 +11,7 @@ cookbook "rbenv", "1.7.1"
 cookbook "ruby_build", "0.8.0"
 
 # Our own cookbooks from vendor/
+cookbook "bundler", path: "vendor/cookbooks/bundler"
 cookbook "packages", path: "vendor/cookbooks/packages"
 cookbook "rails", path: "vendor/cookbooks/rails"
 cookbook "ssh_deploy_keys", path: "vendor/cookbooks/ssh_deploy_keys"

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -60,6 +60,11 @@ SITE
       yum (~> 3.0)
 
 PATH
+  remote: vendor/cookbooks/bundler
+  specs:
+    bundler (0.1.0)
+
+PATH
   remote: vendor/cookbooks/packages
   specs:
     packages (0.1.0)
@@ -81,6 +86,7 @@ PATH
 
 DEPENDENCIES
   apt (= 2.3.8)
+  bundler (>= 0)
   mysql (= 5.1.8)
   nginx (= 2.6.2)
   packages (>= 0)

--- a/vendor/cookbooks/bundler/CHANGELOG.md
+++ b/vendor/cookbooks/bundler/CHANGELOG.md
@@ -1,0 +1,12 @@
+# CHANGELOG for bundler
+
+This file is used to list changes made in each version of bundler.
+
+## 0.1.0:
+
+* Initial release of bundler
+
+- - - 
+Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
+
+The [Github Flavored Markdown page](http://github.github.com/github-flavored-markdown/) describes the differences between markdown on github and standard markdown.

--- a/vendor/cookbooks/bundler/README.md
+++ b/vendor/cookbooks/bundler/README.md
@@ -1,0 +1,12 @@
+Description
+===========
+
+Requirements
+============
+
+Attributes
+==========
+
+Usage
+=====
+

--- a/vendor/cookbooks/bundler/attributes/default.rb
+++ b/vendor/cookbooks/bundler/attributes/default.rb
@@ -1,0 +1,1 @@
+default[:bundler][:version] = "1.2.1"

--- a/vendor/cookbooks/bundler/metadata.json
+++ b/vendor/cookbooks/bundler/metadata.json
@@ -1,0 +1,29 @@
+{
+  "name": "bundler",
+  "description": "Installs/Configures bundler",
+  "long_description": "Description\n===========\n\nRequirements\n============\n\nAttributes\n==========\n\nUsage\n=====\n\n",
+  "maintainer": "Michiel Sikkes",
+  "maintainer_email": "michiel@firmhouse.com",
+  "license": "Apache 2.0",
+  "platforms": {
+  },
+  "dependencies": {
+  },
+  "recommendations": {
+  },
+  "suggestions": {
+  },
+  "conflicting": {
+  },
+  "providing": {
+  },
+  "replacing": {
+  },
+  "attributes": {
+  },
+  "groupings": {
+  },
+  "recipes": {
+  },
+  "version": "0.1.0"
+}

--- a/vendor/cookbooks/bundler/metadata.rb
+++ b/vendor/cookbooks/bundler/metadata.rb
@@ -1,0 +1,6 @@
+maintainer       "Michiel Sikkes"
+maintainer_email "michiel@firmhouse.com"
+license          "Apache 2.0"
+description      "Installs/Configures bundler"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "0.1.0"

--- a/vendor/cookbooks/bundler/recipes/default.rb
+++ b/vendor/cookbooks/bundler/recipes/default.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: bundler
+# Recipe:: default
+#
+# Copyright 2012, Michiel Sikkes
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+gem_package "bundler" do
+  version node[:bundler][:version]
+end


### PR DESCRIPTION
I had a version of the old locomotive-chef-repo around (that now redirects to this repo) and upon digging into it found that it had a custom 'bundler' recipe.  I added this to the vendor directory, pointed the Cheffile at it, and tested it.  This appears to resolve #58.  Not sure if this approach is kosher in the updated style of the repo, so would be happy to see a better alternative.
