### PR TITLE
Use Upstart to run Unicorn

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu/trusty64"
-  # config.vm.box = "ubuntu/precise64"
+  # config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/precise64"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
@@ -115,7 +115,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       chef.log_level = :info
 
-      json_payload["active_applications"]["intercity_sample_app"]["database_info"]["adapter"] = "postgresql"
+      if json_payload["active_applications"].size > 0
+        json_payload["active_applications"]["intercity_sample_app"]["database_info"]["adapter"] = "postgresql"
+      end
 
       # You may also specify custom JSON attributes:
       chef.json = json_payload
@@ -134,7 +136,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       chef.log_level = :info
 
-      json_payload["active_applications"]["intercity_sample_app"]["database_info"]["adapter"] = "mysql2"
+      if json_payload["active_applications"].size > 0
+        json_payload["active_applications"]["intercity_sample_app"]["database_info"]["adapter"] = "mysql2"
+      end
 
       # You may also specify custom JSON attributes:
       chef.json = json_payload

--- a/roles/rails.rb
+++ b/roles/rails.rb
@@ -1,10 +1,21 @@
 name 'rails'
 description 'This role configures a Rails stack using Unicorn'
-run_list "role[base]", "recipe[packages]", "recipe[bluepill]", "recipe[nginx]", "recipe[rails]", "recipe[ruby_build]", "recipe[rbenv]", "recipe[rails::databases]", "recipe[git]", "recipe[ssh_deploy_keys]", "recipe[postfix]", "recipe[rails::env_vars]"
+run_list(
+  "role[base]",
+  "recipe[packages]",
+  "recipe[nginx]",
+  "recipe[rails]",
+  "recipe[ruby_build]",
+  "recipe[rbenv]",
+  "recipe[rails::databases]",
+  "recipe[git]",
+  "recipe[ssh_deploy_keys]",
+  "recipe[postfix]",
+  "recipe[rails::env_vars]"
+)
 
 default_attributes(
   "nginx" => { "server_tokens" => "off" },
-  "bluepill" => { "bin" => "/usr/local/bin/bluepill" },
   "rbenv" => {
     "group_users" => ['deploy']
   },

--- a/vendor/cookbooks/rails/templates/default/app_nginx.conf.erb
+++ b/vendor/cookbooks/rails/templates/default/app_nginx.conf.erb
@@ -45,5 +45,5 @@ server {
 <% end %>
 
 upstream <%= @name %> {
-  server unix:<%= node['rails']['applications_root'] %>/<%= @name %>/shared/sockets/unicorn.sock;
+  server unix:<%= node['rails']['applications_root'] %>/<%= @name %>/shared/tmp/sockets/unicorn.sock;
 }

--- a/vendor/cookbooks/rails/templates/default/app_unicorn.rb.erb
+++ b/vendor/cookbooks/rails/templates/default/app_unicorn.rb.erb
@@ -9,7 +9,7 @@ app_path = "<%= node['rails']['applications_root'] %>/<%= @name %>"
 worker_processes <%= @number_of_workers || 2 %>
 preload_app true
 timeout 30
-listen "#{app_path}/shared/sockets/unicorn.sock", :backlog => 2048
+listen "#{app_path}/shared/tmp/sockets/unicorn.sock", :backlog => 2048
 
 # Spawn unicorn master worker for user apps (group: apps)
 user '<%= @deploy_user %>', '<%= @deploy_user %>'
@@ -25,7 +25,7 @@ stderr_path "log/unicorn.log"
 stdout_path "log/unicorn.log"
 
 # Set master PID location
-pid "#{app_path}/shared/pids/unicorn.pid"
+pid "#{app_path}/shared/tmp/pids/unicorn.pid"
 
 before_exec do |server|
   ENV["BUNDLE_GEMFILE"] = "#{app_path}/current/Gemfile"

--- a/vendor/cookbooks/rails/templates/default/unicorn_upstart.erb
+++ b/vendor/cookbooks/rails/templates/default/unicorn_upstart.erb
@@ -1,0 +1,18 @@
+description "<%= @name %>"
+
+start on virtual-filesystems
+stop on runlevel [06]
+
+env PATH=/opt/rbenv/shims:/opt/rbenv/bin:/usr/local/bin:/usr/bin:/bin:/sbin
+
+env RAILS_ENV=<%= @rails_env %>
+env RACK_ENV=<%= @rails_env %>
+
+setuid <%= @deploy_user %>
+setgid <%= @deploy_user %>
+
+chdir <%= @application_root %>/current
+
+pre-start exec start-stop-daemon -u deploy -g deploy -d <%= @application_root %>/current --start -p <%= @application_root %>/current/tmp/pids/unicorn.pid --exec <%= @application_root %>/current/bin/unicorn -- -D -c <%= @application_root %>/current/config/unicorn.rb -E <%= @rails_env %>
+
+post-stop exec start-stop-daemon --stop -p <%= @application_root %>/current/tmp/pids/unicorn.pid


### PR DESCRIPTION
This Pull Request replaces Bluepill with Runit to start Unicorn. Runit is the default init system on Ubuntu 12.04 and 14.04.

It fixes many problems that we currently have with Bluepill. Bluepill won't be able to build on default machine images because the cookbook is outdated and uses the Ruby version that is installed on the server, instead of using the vendor-supplied with Chef omnibus.

Using Upstart for starting Unicorn at machine runtime, will be a more solid solution for using the Unicorn stack.
## Impact

This Pull request has some impact on current servers. Namely, the Bluepill daemon will be kept installed on current servers that use the "old" way of launching Unicorn. This is not a big problem because on a server reboot Upstart will launch the Unicorn daemon itself and Bluepill will check the Unicorn pid file. But perhaps this upgrade causes problems for some users.
