### PR TITLE
Downloaded Ruby binary isn't cleared after installing

### DIFF
--- a/vendor/cookbooks/rails/attributes/default.rb
+++ b/vendor/cookbooks/rails/attributes/default.rb
@@ -1,10 +1,10 @@
-default['rails']['applications_root'] = '/u/apps'
-default['rbenv']['binaries_url'] = 'https://intercityup.com/binaries/ruby/ubuntu/'
-default['rbenv']['available_binaries'] = %w{1.9.3-p547 2.0.0-p481 2.1.1 2.1.2}
+default["rails"]["applications_root"] = "/u/apps"
+default["rbenv"]["binaries_url"] = "https://intercityup.com/binaries/ruby/ubuntu"
+default["rbenv"]["available_binaries"] = %w(1.9.3-p547 2.0.0-p481 2.1.1 2.1.2)
 
-case node['platform_family']
-when 'debian'
-  if node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
-    default['nginx']['pid'] = '/run/nginx.pid'
+case node["platform_family"]
+when "debian"
+  if node["platform"] == "ubuntu" && node["platform_version"] == "14.04"
+    default["nginx"]["pid"] = "/run/nginx.pid"
   end
 end

--- a/vendor/cookbooks/rails/recipes/ruby_binaries.rb
+++ b/vendor/cookbooks/rails/recipes/ruby_binaries.rb
@@ -12,8 +12,11 @@ if node[:active_applications]
           user node[:rbenv][:user]
           group node[:rbenv][:group]
           cwd "#{node[:rbenv][:root_path]}/versions"
-          command "wget #{node[:rbenv][:binaries_url]}#{node["platform_version"]}/#{kernel_architecture}/#{ruby_binary};" \
-            "tar jxf #{ruby_binary}"
+          command <<-EOM
+              wget #{node[:rbenv][:binaries_url]}/#{node["platform_version"]}/#{kernel_architecture}/#{ruby_binary};
+              tar jxf #{ruby_binary}
+              rm #{ruby_binary}
+            EOM
           not_if {  File.directory?(File.join('opt', 'rbenv', 'versions', ruby_version)) }
         end
       end


### PR DESCRIPTION
In my opinion it is best to clear out the downloaded `ruby-x.x.x.tar.bz2` binary file after we extracted it into the `rbenv/versions` directory. This will clean up the `versions` directory and it will allow easy re-installing of binaries by just removing the `versions/x.x.x` directory. After that our Chef cookbooks will re-download a new `.tar.bz2` and extract it in the new location.
