### PR TITLE
Added an UPGRADING guide with upgrade instructions for newer versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,19 @@ This project makes use of the [Sementic Versioning](http://semver.org/)
 
 ## 2.1.0 - TBA
 
+See [UPGRADING.md](UPGRADING.md) for upgrade instructions if you're using the Unicorn stack.
+
 ### Added
-- Starting working with a [Changelog](http://keepachangelog.com/)
-- Added support for [Rbenv-vars](https://github.com/sstephenson/rbenv-vars)
-- Added support for pre-build ruby packages for a blazing fast ruby installation
+- Started working with a [Changelog](http://keepachangelog.com/)
+- Configure ENV vars for your apps [Rbenv-vars](https://github.com/sstephenson/rbenv-vars)
+- Speed up Ruby installation with binary packages
+- [Unicorn Stack] Use Upstart to start Unicorn
 
 ### Deprecated
 - Nothing.
 
 ### Removed
-- Nothing.
+- [Unicorn Stack] Don't use Bluepill monitoring for Unicorn anymore.
 
 ### Fixed
 - Nothing.
@@ -21,9 +24,9 @@ This project makes use of the [Sementic Versioning](http://semver.org/)
 ## 2.0.0 - 2014-04-28
 
 ### Added
-- Support for Phusian Passenger
-- Support for Postgresql
-- Use a cheffile with Librarian-chef to manage cookbooks
+- Use Phusion Passenger as default Rails stack.
+- Use Postgresql as your database
+- Use Cheffile with Librarian-Chef to manage cookbooks
 
 ### Deprecated
 - Nothing.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,25 @@
+Upgrading your server to newer versions of this repository
+==========================================================
+
+This guide provides steps to upgrade your server to newer versions of the cookbooks in this repository.
+
+Upgrading from chef-repo 2.0.0 to 2.1.0
+---------------------------------------
+
+### Unicorn Stack: Clean up Bluepill
+
+Running Unicorn from Bluepill was removed in this version. You will need to clean up older Bluepill processes and configuration files manually.
+
+After updating your server with the most recent versions of these cookbooks by using the `knife cook` command follow the next steps:
+
+On your server, quit all current Bluepill processes by running:
+
+```
+sudo /opt/chef/embedded/bin/bluepill quit
+```
+
+Then, remove the Bluepill configuration files from `/etc/bluepill`:
+
+```
+sudo rm /etc/bluepill/*
+```


### PR DESCRIPTION
This PR adds an initial `UPGRADING.md` file that can serve as a guide for showing people how to upgrade their servers to newer versions of the cookbooks in our repository. It is inspired by the Rails upgrading guide at http://guides.rubyonrails.org/upgrading_ruby_on_rails.html.
