### PR TITLE
Ignore certificates dir as it contains the certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/
 nodes/*.json
 !nodes/sample_host.json
 /cookbooks
+/certificates
 /tmp
 .vagrant
 


### PR DESCRIPTION
Ignore the certificates directory: this is probably the place where people want to store their SSL-keys. And as such you probably don't want this in the RCS.
