### PR TITLE
Make nokogiri use syslibs

### DIFF
--- a/vendor/cookbooks/backups/recipes/default.rb
+++ b/vendor/cookbooks/backups/recipes/default.rb
@@ -24,6 +24,9 @@ if backup_node
   package "ruby1.9.1-dev"
   package "libxml2-dev"
   package "libxslt-dev"
+
+  # Speed up nokogiri install by using syslibs
+  ENV["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
   gem_package "backup"
 
   backup_node.each do |app, backup_info|


### PR DESCRIPTION
This speeds up the installation of a server a lot!
Originally the time was 6.x minutes, after this change it is 4.x minutes
