### PR TITLE
Add ImageMagick to default Rails install

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -11,6 +11,7 @@ cookbook "postfix", "~> 3.4.0"
 cookbook "sudo", "~> 2.7.0"
 cookbook "rbenv", "~> 1.7.1"
 cookbook "ruby_build", "~> 0.8.0"
+cookbook "imagemagick", "~> 0.2.3"
 
 # Our own cookbooks from vendor/
 cookbook "packages", path: "vendor/cookbooks/packages"

--- a/vendor/cookbooks/rails/recipes/default.rb
+++ b/vendor/cookbooks/rails/recipes/default.rb
@@ -21,6 +21,7 @@ include_recipe "sudo"
 include_recipe "nginx"
 
 include_recipe "rails::setup"
+include_recipe "rails::imagemagick"
 
 applications_root = node[:rails][:applications_root]
 

--- a/vendor/cookbooks/rails/recipes/imagemagick.rb
+++ b/vendor/cookbooks/rails/recipes/imagemagick.rb
@@ -1,0 +1,2 @@
+include_recipe 'imagemagick'
+include_recipe 'imagemagick::devel'


### PR DESCRIPTION
This may not be the best place for it, but I figured I would bring it up for discussion. I am using this repository to stage a somewhat simple Rails application and came across a need for ImageMagick as part of the popular [Paperclip](https://github.com/thoughtbot/paperclip) gem. As I went to foil-ball it on the server, it occurred to me that wouldn't be a very good idea in terms of adhering to good configuration management.

This PR adds a reference to the upstream `imagemagick` cookbook from OpsCode (if I did it right) to be installed as part of the Rails stack.
