### PR TITLE
Rake should be part of the gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "rake"
 gem "chef", "~> 11.16.2"
 gem "knife-solo", "~> 0.4.1"
 gem "librarian-chef", "~> 0.0.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.5.2)
+    rake (10.3.2)
     resource_kit (0.0.5)
       activesupport (>= 3.0)
       addressable (~> 2.3.6)
@@ -170,6 +171,7 @@ DEPENDENCIES
   kitchen-vagrant
   knife-solo (~> 0.4.1)
   librarian-chef (~> 0.0.4)
+  rake
   rspec
   serverspec
   test-kitchen


### PR DESCRIPTION
This PR adds rake to the Gemfile. 

While most setups and systems already have rake, some, especially when working with a ruby-version manager, might not. Moreover, they might have a version of rake that is incompatible with what this repo needs or wants.
By adding this as dependency to the Gemfile, we can make sure everyone has the same rake when running this repo's raketasks.
