### PR TITLE
  Add ability to create Redirect Domains.

### DIFF
--- a/nodes/sample_host.json
+++ b/nodes/sample_host.json
@@ -37,6 +37,7 @@
       "rails_env": "<stage, eg: production>",
       "packages": ["nodejs"],
       "domain_names": ["<domain name>", "<domain name>", "<...>"],
+      "redirect_domain_names": ["<domain name>", "<domain name>", "<...>"],
       "ruby_version": "2.1.0",
       "ssl_info": {
         "key": "<ssl key>",

--- a/vendor/cookbooks/rails/recipes/default.rb
+++ b/vendor/cookbooks/rails/recipes/default.rb
@@ -105,7 +105,10 @@ if node[:active_applications]
 
     template "/etc/nginx/sites-available/#{app}.conf" do
       source "app_nginx.conf.erb"
-      variables :name => app, :domain_names => app_info['domain_names'], :enable_ssl => File.exists?("#{applications_root}/#{app}/shared/config/certificate.crt")
+      variables :name => app,
+        :domain_names => app_info['domain_names'],
+        :redirect_domain_names => app_info['redirect_domain_names'],
+        :enable_ssl => File.exists?("#{applications_root}/#{app}/shared/config/certificate.crt")
       notifies :reload, resources(:service => "nginx")
     end
 

--- a/vendor/cookbooks/rails/templates/default/app_nginx.conf.erb
+++ b/vendor/cookbooks/rails/templates/default/app_nginx.conf.erb
@@ -1,3 +1,14 @@
+<% if @redirect_domain_names && @redirect_domain_names.any? %>
+server {
+  listen <%= node['nginx']['port'] || '80' %>;
+  <% if @enable_ssl %>
+  listen 443 ssl;
+  <% end %>
+  server_name <%= @redirect_domain_names.join(' ') %>;
+  return 301 $scheme://<%= @domain_names.first %>$request_uri;
+}
+<% end %>
+
 server {
   listen <%= node['nginx']['port'] || '80' %>;
   server_name <%= @domain_names.join(' ') %>;


### PR DESCRIPTION
This introduces an extra, optional, setting with a list of domains that should redirect to the main app.
## Usecases:
- www to non-www, or viceversa redirection
- Alternative domains that should redirect to the main app.
## Examples:

``` @json
  domain_names: ['example.com']
  redirect_domain_names: ['www.example.com']
```

  www.example.com will now redirect to example.com

``` @json
  domain_names: ['example.com', 'example.net']
  redirect_domain_names: ['example.org', 'www.example.org']
```

  example.org and www.example.org will now redirect to example.com. Application can be served on example.com and example.net.

It only handles redirects on domains. I cannot be used to redirect from/to https. And it cannot be used for rewrites or u    rl-redirects (like example.com/foo -> example.com/content/foo). Just domains.

  I'll add some documentation for the wiki in a followup comment.
