### PR TITLE
Fixed #165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ This project makes use of the [Sementic Versioning](http://semver.org/)
 ### Misc
 - Nothing
 
+## 2.3.1 - 2015-02-10
+
+### Fixed
+- Fixed `Mysql2::Error: CREATE command denied to user` issue after `database`
+  cookbook upgrade.
+
 ## 2.3.0 - 2014-12-30
 
 ### Added

--- a/vendor/cookbooks/rails/recipes/databases.rb
+++ b/vendor/cookbooks/rails/recipes/databases.rb
@@ -22,7 +22,6 @@ if node[:active_applications]
           username database_username
           password database_password
           database_name(database_name)
-          table "*"
           host "localhost"
           action :grant
         end


### PR DESCRIPTION
The `table "*"` option in mysql_database resource is not valid anymore for database cookbook v2.3.1