### PR TITLE
Sets encoding to utf-8 for sysadmins metadata file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project makes use of the [Sementic Versioning](http://semver.org/)
 
 ### Fixed
 - Allow redirect domains to be set for the Passenger stack as well
+- Set encoding to utf-8 for sysadmins metadata file
 
 ### Misc
 - Downgraded to ruby 2.1.5

--- a/vendor/cookbooks/sysadmins/metadata.rb
+++ b/vendor/cookbooks/sysadmins/metadata.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 name "sysadmins"
 maintainer "Bèr `berkes` Kessels"
 maintainer_email "ber@berk.es"


### PR DESCRIPTION
Installing my local Vagrant box threw the following error:
```
ERROR: /home/vagrant/chef-solo/cookbooks-2/sysadmins/metadata.rb:2: invalid multibyte char (US-ASCII)
```
I was able to solve this by setting the encoding explicitly to utf-8 for the ```metadata.rb``` file so that @berkes's name would be handled properly.