### PR TITLE
Removed bin as part of linked directories in Capistrano.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ set :ssh_options, {
 set :pty, true
 
 set :linked_files, %w{config/database.yml .rbenv-vars .ruby-version}
-set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 
 set :default_env, { path: "/opt/rbenv/shims:$PATH" }
 


### PR DESCRIPTION
Removed `bin` folder as part of linked directories in Capistrano in order to run `bin/rails c` inside the server.