### PR TITLE
Touch nginx when certificate files are created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project makes use of the [Sementic Versioning](http://semver.org/)
 ### Fixed
 - Allow redirect domains to be set for the Passenger stack as well
 - Set encoding to utf-8 for sysadmins metadata file
+- Reload NGINX once a certificate has changed
 
 ### Misc
 - Downgraded to ruby 2.1.5

--- a/vendor/cookbooks/rails/recipes/passenger.rb
+++ b/vendor/cookbooks/rails/recipes/passenger.rb
@@ -117,6 +117,7 @@ if node[:active_applications]
         mode 0644
         source "app_cert.crt.erb"
         variables :app_crt=> app_info['ssl_info']['crt']
+        notifies :reload, resources(service: "nginx")
       end
 
       template "#{applications_root}/#{app}/shared/config/certificate.key" do
@@ -125,6 +126,7 @@ if node[:active_applications]
         mode 0644
         source "app_cert.key.erb"
         variables :app_key=> app_info['ssl_info']['key']
+        notifies :reload, resources(service: "nginx")
       end
       has_ssl_info = true
     end


### PR DESCRIPTION
This fixes an issue where a user uploads a new certificate with IC, but then NGINX is not being reloaded, so the changed are never applied.

/cc @michiels @joshuajansen 