### PR TITLE
Added the ability to remove your application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project makes use of the [Sementic Versioning](http://semver.org/)
 
 ### Added
 - Ruby 2.1.5 is now installed from binaries
+- Ability to remove an application from your server
 
 ### Deprecated
 - Nothing

--- a/nodes/sample_host.json
+++ b/nodes/sample_host.json
@@ -1,5 +1,5 @@
 {
-  "run_list":["role[mysql]","role[rails_passenger]", "role[sysadmins]"],
+  "run_list":["role[mysql]","role[remove_applications]", "role[rails_passenger]", "role[sysadmins]"],
   "mysql": {
     "server_debian_password": "<enter a random password>",
     "server_root_password": "<enter a random password>",
@@ -18,6 +18,7 @@
   "ssh_deploy_keys": [
     "<enter the contents of an id_rsa.pub here>"
   ],
+  "remove_applications": ["<app_name>_<stage>"],
   "backups": {
     "<app_name>_<stage>" : {
       "enabled": true,

--- a/roles/remove_applications.rb
+++ b/roles/remove_applications.rb
@@ -1,0 +1,5 @@
+name "remove_applications"
+description "This role safely removes applications from your server"
+run_list(
+  "recipe[rails::remove_applications]"
+)

--- a/vendor/cookbooks/rails/metadata.rb
+++ b/vendor/cookbooks/rails/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "michiel@firmhouse.com"
 license          "MIT"
 description      "Installs/Configures rails"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.0"
+version          "0.3.0"
 depends "rbenv", "~> 1.7.1"
 depends "sudo", "> 1.2.0"
 depends "database"

--- a/vendor/cookbooks/rails/recipes/remove_applications.rb
+++ b/vendor/cookbooks/rails/recipes/remove_applications.rb
@@ -1,0 +1,58 @@
+#
+# Cookbook Name:: rails::remove_applications
+# Recipe:: default
+#
+# Copyright 2012, Michiel Sikkes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+applications_root = node[:rails][:applications_root]
+
+include_recipe "nginx"
+
+if node[:remove_applications]
+  node[:remove_applications].each do |app|
+    file "/etc/nginx/sites-enabled/#{app}.conf" do
+      manage_symlink_source true
+      action :delete
+      notifies :reload, resources(service: "nginx")
+    end
+
+    file "/etc/nginx/sites-available/#{app}.conf" do
+      action :delete
+    end
+
+    directory "#{applications_root}/#{app}" do
+      recursive true
+      action :delete
+    end
+
+    logrotate_app "rails-#{app}" do
+      enable false
+    end
+
+    cron "backup_#{app}" do
+      user "deploy"
+      action :delete
+    end
+
+    file "/home/deploy/Backup/models/#{app}.rb" do
+      action :delete
+    end
+  end
+end


### PR DESCRIPTION
By adding `"remove_applications": ["your_app_name"]` to your json node you can now remove the application from the server.

In this first version we clean up the following things:
1) App files (`/u/apps/app_name`)
2) Disable log_rotate
3) Remove the NGINX config
4) Disable the backup cron
5) Remove the backup config file.

I'm not super happy with the name `remove_applications` for the recipe. So if you can come up with a better name, please let me know!

![internet-typing1](https://cloud.githubusercontent.com/assets/1362793/6641305/4f69b2ec-c99d-11e4-912b-ea480dc6f922.gif)

/cc @joshuajansen @michiels 

