### PR TITLE
Added libffi-dev as a system package for ruby 2.2.x instalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project makes use of the [Sementic Versioning](http://semver.org/)
 - Allow redirect domains to be set for the Passenger stack as well
 - Set encoding to utf-8 for sysadmins metadata file
 - Reload NGINX once a certificate has changed
+- Ruby 2.2.x dependency `libffi-dev` is now installed.
 
 ### Misc
 - Downgraded to ruby 2.1.5

--- a/vendor/cookbooks/rails/recipes/default.rb
+++ b/vendor/cookbooks/rails/recipes/default.rb
@@ -27,6 +27,8 @@ include_recipe "nginx"
 
 include_recipe "rails::setup"
 
+package "libffi-dev"
+
 applications_root = node[:rails][:applications_root]
 
 if node[:active_applications]

--- a/vendor/cookbooks/rails/recipes/passenger.rb
+++ b/vendor/cookbooks/rails/recipes/passenger.rb
@@ -23,6 +23,7 @@
 # THE SOFTWARE.
 
 package "apt-transport-https"
+package "libffi-dev"
 
 apt_repository "passenger" do
   uri "https://oss-binaries.phusionpassenger.com/apt/passenger"


### PR DESCRIPTION
This is needed in order to be able to compile ruby 2.2.x on Ubuntu systems.

See https://github.com/sstephenson/ruby-build/issues/690 and https://github.com/sstephenson/ruby-build/wiki#build-failure-of-fiddle-with-ruby-220

/cc @michiels / @joshuajansen 

![i-must-fit](https://cloud.githubusercontent.com/assets/1362793/6865129/114d02ec-d46b-11e4-8275-f9f72327bcb2.gif)
