### PR TITLE
Add ruby 2.2.1 to the available binaries list

### DIFF
--- a/vendor/cookbooks/rails/attributes/default.rb
+++ b/vendor/cookbooks/rails/attributes/default.rb
@@ -1,6 +1,6 @@
 default["rails"]["applications_root"] = "/u/apps"
 default["rbenv"]["binaries_url"] = "http://binaries.intercityup.com/ruby/ubuntu"
-default["rbenv"]["available_binaries"] = %w(1.9.3-p547 2.0.0-p481 2.1.1 2.1.2 2.1.3 2.1.5)
+default["rbenv"]["available_binaries"] = %w(1.9.3-p547 2.0.0-p481 2.1.1 2.1.2 2.1.3 2.1.5 2.2.1)
 
 case node["platform_family"]
 when "debian"


### PR DESCRIPTION
This depends on the actual build of the binaries. I'm running them as I type :)

![double-fail](https://cloud.githubusercontent.com/assets/1362793/6868802/cc2313fe-d48e-11e4-8dd4-5f6ce37549be.gif)
