### PR TITLE
Fix Ruby 2.2.0 build errors

### DIFF
--- a/vendor/cookbooks/rails/metadata.rb
+++ b/vendor/cookbooks/rails/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "michiel@firmhouse.com"
 license          "MIT"
 description      "Installs/Configures rails"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.3.0"
+version          "0.3.1"
 depends "rbenv", "~> 1.7.1"
 depends "sudo", "> 1.2.0"
 depends "database"

--- a/vendor/cookbooks/rails/recipes/default.rb
+++ b/vendor/cookbooks/rails/recipes/default.rb
@@ -27,8 +27,6 @@ include_recipe "nginx"
 
 include_recipe "rails::setup"
 
-package "libffi-dev"
-
 applications_root = node[:rails][:applications_root]
 
 if node[:active_applications]

--- a/vendor/cookbooks/rails/recipes/passenger.rb
+++ b/vendor/cookbooks/rails/recipes/passenger.rb
@@ -23,7 +23,6 @@
 # THE SOFTWARE.
 
 package "apt-transport-https"
-package "libffi-dev"
 
 apt_repository "passenger" do
   uri "https://oss-binaries.phusionpassenger.com/apt/passenger"

--- a/vendor/cookbooks/rails/recipes/setup.rb
+++ b/vendor/cookbooks/rails/recipes/setup.rb
@@ -27,6 +27,8 @@ if node[:deploy_users]
   end
 end
 
+package "libffi-dev"
+
 include_recipe "rbenv::default"
 include_recipe "rbenv::ruby_build"
 include_recipe "rbenv::rbenv_vars"


### PR DESCRIPTION
This PR fixes the Ruby 2.2.0 FFI build errors by adding a default package dependency of "libffi-dev" to the Rails setup recipes.

See for reference:
https://github.com/sstephenson/ruby-build/issues/690

and https://github.com/sstephenson/ruby-build/wiki#build-failure-of-fiddle-with-ruby-220