### PR TITLE
Allow for setting DB pool size via ENV vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project makes use of the [Sementic Versioning](http://semver.org/)
 
+## Unreleased
+
+### Added
+- Set the max db `pool` size via an ENV var called `DB_POOL_SIZE`
+
 ## 2.5.0 - 2015-04-30
 
 ### Added

--- a/vendor/cookbooks/rails/templates/default/app_database.yml.erb
+++ b/vendor/cookbooks/rails/templates/default/app_database.yml.erb
@@ -3,7 +3,7 @@
   host: <%= @database_info['host'] %>
   username: <%= @database_info['username'] %>
   password: <%= @database_info['password'] %>
-  pool: 5
+  pool: <%%= ENV['DB_POOL_SIZE'] || 5 %>
   timeout: 5000
   database: <%= @database_info['database'] %>
   encoding: utf8


### PR DESCRIPTION
In some cases the default pool size of 5 might be to little, by allowing you to
edit the ENV vars of the app, you can easily change this var.

/cc @michiels 