### PR TITLE
Fix box could not be found

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "chef/ubuntu-14.04"
-  # config.vm.box = "chef/ubuntu-12.04"
+  config.vm.box = "bento/ubuntu-14.04"
+  # config.vm.box = "bento/ubuntu-12.04"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.


### PR DESCRIPTION
After completing all required steps and trying to run `vagrant up mysql` I got the following error:

```
Bringing machine 'mysql' up with 'virtualbox' provider...
==> mysql: Box 'chef/ubuntu-14.04' could not be found. Attempting to find and install...
    mysql: Box Provider: virtualbox
    mysql: Box Version: >= 0
==> mysql: Loading metadata for box 'chef/ubuntu-14.04'
    mysql: URL: https://atlas.hashicorp.com/chef/ubuntu-14.04
The box you're adding has a name different from the name you
requested. For boxes with metadata, you cannot override the name.
If you're adding a box using `vagrant box add`, don't specify
the `--name` parameter. If the box is being added via a Vagrantfile,
change the `config.vm.box` value to match the name below.

Requested name: chef/ubuntu-14.04
Actual name: bento/ubuntu-14.04
```

Renaming `config.vm.box` to `bento/ubuntu-14.04` fixed the issue.