### PR TITLE
Feature/per app access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project makes use of the [Sementic Versioning](http://semver.org/)
 
 ### Added
 - Set the max db `pool` size via an ENV var called `DB_POOL_SIZE`
+- Ability to define per-app IP-address white and blacklists that may access the app.
 
 ## 2.5.0 - 2015-04-30
 

--- a/vendor/cookbooks/rails/libraries/default.rb
+++ b/vendor/cookbooks/rails/libraries/default.rb
@@ -16,5 +16,16 @@ module Rails
 
       empty_conf.merge(app_info["nginx_custom"] || {})
     end
+
+    ##
+    # Create a rendered set of access and deny rules for nginx conf.
+    # Ensures we always have a string to render.
+    def nginx_access(app_info)
+      # Ensure we always have a hash, and dup to make it writable
+      access = app_info.fetch("access", {}).dup
+      access["allowed"] ||= []
+      access["denied"]  ||= []
+      access
+    end
   end
 end

--- a/vendor/cookbooks/rails/recipes/default.rb
+++ b/vendor/cookbooks/rails/recipes/default.rb
@@ -119,7 +119,8 @@ if node[:active_applications]
         redirect_domain_names: app_info["redirect_domain_names"],
         client_max_body_size: app_info["client_max_body_size"],
         enable_ssl: File.exists?("#{applications_root}/#{app}/shared/config/certificate.crt"),
-        custom_configuration: nginx_custom_configuration(app_info))
+        custom_configuration: nginx_custom_configuration(app_info),
+        access: nginx_access(app_info))
       notifies :reload, resources(service: "nginx")
     end
 

--- a/vendor/cookbooks/rails/recipes/passenger.rb
+++ b/vendor/cookbooks/rails/recipes/passenger.rb
@@ -142,7 +142,8 @@ if node[:active_applications]
         redirect_domain_names: app_info["redirect_domain_names"],
         client_max_body_size: app_info["client_max_body_size"],
         enable_ssl: enable_ssl,
-        custom_configuration: nginx_custom_configuration(app_info))
+        custom_configuration: nginx_custom_configuration(app_info),
+        access: nginx_access(app_info))
       notifies :reload, resources(:service => "nginx")
     end
 

--- a/vendor/cookbooks/rails/templates/default/app_nginx.conf.erb
+++ b/vendor/cookbooks/rails/templates/default/app_nginx.conf.erb
@@ -26,6 +26,7 @@ server {
     proxy_pass http://<%= @name %>;
     <%= @custom_configuration["server_app"] %>
   }
+  <%= render 'nginx/access.erb', variables: { access: @access } %>
   <%= @custom_configuration["server_main"] %>
 }
 
@@ -54,6 +55,7 @@ server {
     proxy_pass http://<%= @name %>;
     <%= @custom_configuration["ssl_app"] %>
   }
+  <%= render 'nginx/access.erb', variables: { access: @access } %>
   <%= @custom_configuration["ssl_main"] %>
 }
 

--- a/vendor/cookbooks/rails/templates/default/app_passenger_nginx.conf.erb
+++ b/vendor/cookbooks/rails/templates/default/app_passenger_nginx.conf.erb
@@ -32,7 +32,7 @@ server {
   passenger_app_env <%= @rails_env %>;
 
   <%= "client_max_body_size #{@client_max_body_size};" if @client_max_body_size.to_i != 0 %>
-
+  <%= render 'nginx/access.erb', variables: { access: @access } %>
   <%= @custom_configuration["server_main"] %>
 }
 
@@ -54,8 +54,8 @@ server {
   <%= "client_max_body_size #{@client_max_body_size};" if @client_max_body_size.to_i != 0 %>
 
   server_name <%= @domain_names.join(' ') %>;
-
   root <%= node['rails']['applications_root'] %>/<%= @name %>/current/public;
+  <%= render 'nginx/access.erb', variables: { access: @access } %>
   <%= @custom_configuration["ssl_main"] %>
 }
 

--- a/vendor/cookbooks/rails/templates/default/nginx/access.erb
+++ b/vendor/cookbooks/rails/templates/default/nginx/access.erb
@@ -1,0 +1,9 @@
+<% @access["denied"].each do |denied_address| %>
+  deny <%= denied_address %>;
+<% end %>
+<% @access["allowed"].each do |allowed_address| %>
+  allow <%= allowed_address %>;
+<% end %>
+<% if @access["allowed"].any? %>
+  deny all;
+<% end %>


### PR DESCRIPTION
This adds a whitelisting feature for 



Each app can have an "access" entry. Where you can add a list of IP-addresses
that are allowed. When defined, each address will be added to the nginx configuration as allowed, all other addresses will be denied.

More information on [the Nginx documentation](http://nginx.org/en/docs/http/ngx_http_access_module.html)
The template will add the denied, then the allowed IP-addresses.

        "access": {
          "allowed": ["127.0.0.1"]
        }

This will only allow users from 127.0.0.1 access to the app. All others will be denied.

        "access": {
          "denied": ["127.0.0.1"],
          "allowed": ["127.0.0.0/24"]
        }

This will allow access for users from IP range 127.0.0.0/24, but makes an exception for IP-address 127.0.0.1 which is denied access.

NOTE: the denied is not meant to replace full-blown IP-blocking. Its intended
use is to allow IPB-blocks in allow, then remove one or two specific ones by denying them again.
I.e: to aid the whitelisting, not to be used as a blacklisting. But when using only the denied list, you can have blacklisting. However, the moment you add an allowed address, we add "deny all" to the access configuration.

NOTE: This is not meant to replace access control, nor will it scale well for
large amounts of IP-addresses. The intented use is to open up e.g. a testing version
of an app to a limited set of users.