### PR TITLE
Feature/client max body size unicorn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project makes use of the [Sementic Versioning](http://semver.org/)
 ## Unreleased
 
 ### Added
+- Nginx with unicorn respects and uses the "client_max_body_size" configuration similar to nginx for passenger.
 - Set the max db `pool` size via an ENV var called `DB_POOL_SIZE`
 
 ### Misc

--- a/vendor/cookbooks/rails/metadata.rb
+++ b/vendor/cookbooks/rails/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "michiel@firmhouse.com"
 license          "MIT"
 description      "Installs/Configures rails"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.3.1"
+version          "0.4.1"
 depends "rbenv", "~> 1.7.1"
 depends "sudo", "> 1.2.0"
 depends "database"

--- a/vendor/cookbooks/rails/templates/default/app_nginx.conf.erb
+++ b/vendor/cookbooks/rails/templates/default/app_nginx.conf.erb
@@ -26,6 +26,7 @@ server {
     proxy_pass http://<%= @name %>;
     <%= @custom_configuration["server_app"] %>
   }
+  <%= "client_max_body_size #{@client_max_body_size};" if @client_max_body_size.to_i != 0 %>
   <%= @custom_configuration["server_main"] %>
 }
 
@@ -54,6 +55,7 @@ server {
     proxy_pass http://<%= @name %>;
     <%= @custom_configuration["ssl_app"] %>
   }
+  <%= "client_max_body_size #{@client_max_body_size};" if @client_max_body_size.to_i != 0 %>
   <%= @custom_configuration["ssl_main"] %>
 }
 


### PR DESCRIPTION
In addition to 4d4a710a270cb982e3601a362f038278a8f1fb78 the client_max_body_size is used in unicorn.
